### PR TITLE
fix: v0.1.1 — Android updateContact + duplicate contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGES
 
+## 0.1.1
+
+- Fix `updateContact` failing with "raw_contact_id is required" on Android —
+  it passed the aggregated `CONTACT_ID` to Data-table inserts instead of the
+  `RAW_CONTACT_ID`, so the whole update failed. Updates (including phone
+  numbers) now save correctly. Resolves #6 and #8.
+- Fix duplicate phone numbers / emails on Android for contacts aggregated
+  from multiple accounts — exact duplicates are now dropped. Resolves #9.
+
 ## 0.1.0
 
 - **Fix iOS UIScene crash** — the plugin force-unwrapped `appDelegate.window`,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = "com.example.flutter_contacts_service"
-version = "0.1.0"
+version = "0.1.1"
 
 buildscript {
     ext.kotlin_version = "2.3.21"

--- a/android/src/main/kotlin/com/example/flutter_contacts_service/FlutterContactsServicePlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_contacts_service/FlutterContactsServicePlugin.kt
@@ -742,7 +742,23 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
             }
         }
 
-        return ArrayList(map.values)
+        val contacts = ArrayList(map.values)
+        // A contact aggregated from multiple accounts (e.g. Google + WhatsApp)
+        // can surface the same phone or email twice. Drop exact duplicates
+        // (issue #9).
+        contacts.forEach { contact ->
+            contact.phones =
+                contact.phones.distinctBy { "${it.label}|${it.value}" }.toMutableList()
+            contact.emails =
+                contact.emails.distinctBy { "${it.label}|${it.value}" }.toMutableList()
+            contact.postalAddresses =
+                contact.postalAddresses
+                    .distinctBy {
+                        "${it.label}|${it.street}|${it.city}|${it.postcode}|${it.region}|${it.country}"
+                    }
+                    .toMutableList()
+        }
+        return contacts
     }
 
     private fun setAvatarDataForContactIfAvailable(contact: Contact) {
@@ -914,7 +930,30 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
         }
     }
 
+    /** Resolves the first raw-contact id for an aggregated contact id. */
+    private fun getFirstRawContactId(contactId: String?): String? {
+        if (contactId.isNullOrEmpty()) return null
+        return contentResolver
+            ?.query(
+                ContactsContract.RawContacts.CONTENT_URI,
+                arrayOf(ContactsContract.RawContacts._ID),
+                "${ContactsContract.RawContacts.CONTACT_ID} = ?",
+                arrayOf(contactId),
+                null
+            )
+            ?.use { if (it.moveToFirst()) it.getString(0) else null }
+    }
+
     private fun updateContact(contact: Contact): Boolean {
+        // Data-table inserts require a RAW_CONTACT_ID, not the aggregated
+        // CONTACT_ID. Passing the contact id directly caused
+        // "raw_contact_id is required" failures (issues #6, #8).
+        val rawContactId =
+            getFirstRawContactId(contact.identifier)
+                ?: run {
+                    Log.e("ContactsService", "Error updating contact: raw contact not found")
+                    return false
+                }
         val ops = ArrayList<android.content.ContentProviderOperation>()
 
         val deleteMimeTypes =
@@ -958,7 +997,7 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                     ContactsContract.Data.MIMETYPE,
                     ContactsContract.CommonDataKinds.Organization.CONTENT_ITEM_TYPE
                 )
-                .withValue(ContactsContract.Data.RAW_CONTACT_ID, contact.identifier)
+                .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
                 .withValue(
                     ContactsContract.CommonDataKinds.Organization.TYPE,
                     ContactsContract.CommonDataKinds.Organization.TYPE_WORK
@@ -971,14 +1010,14 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
         ops.add(
             android.content.ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
                 .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Note.CONTENT_ITEM_TYPE)
-                .withValue(ContactsContract.Data.RAW_CONTACT_ID, contact.identifier)
+                .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
                 .withValue(ContactsContract.CommonDataKinds.Note.NOTE, contact.note)
                 .build()
         )
 
         ops.add(
             android.content.ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-                .withValue(ContactsContract.Data.RAW_CONTACT_ID, contact.identifier)
+                .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
                 .withValue(ContactsContract.Data.IS_SUPER_PRIMARY, 1)
                 .withValue(ContactsContract.CommonDataKinds.Photo.PHOTO, contact.avatar)
                 .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE)
@@ -989,7 +1028,7 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
             val op =
                 android.content.ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
                     .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE)
-                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, contact.identifier)
+                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
                     .withValue(ContactsContract.CommonDataKinds.Phone.NUMBER, phone.value)
 
             if (phone.type == ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM) {
@@ -1008,7 +1047,7 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
             ops.add(
                 android.content.ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
                     .withValue(ContactsContract.Data.MIMETYPE, ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE)
-                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, contact.identifier)
+                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
                     .withValue(ContactsContract.CommonDataKinds.Email.ADDRESS, email.value)
                     .withValue(ContactsContract.CommonDataKinds.Email.TYPE, email.type)
                     .build()
@@ -1022,7 +1061,7 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                         ContactsContract.Data.MIMETYPE,
                         ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE
                     )
-                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, contact.identifier)
+                    .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
                     .withValue(ContactsContract.CommonDataKinds.StructuredPostal.TYPE, address.type)
                     .withValue(ContactsContract.CommonDataKinds.StructuredPostal.STREET, address.street)
                     .withValue(ContactsContract.CommonDataKinds.StructuredPostal.CITY, address.city)

--- a/ios/flutter_contacts_service.podspec
+++ b/ios/flutter_contacts_service.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_contacts_service'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'A Flutter plugin to read, create, update and delete device contacts on Android and iOS.'
   s.description      = <<-DESC
 A Flutter plugin for managing device contacts natively — read, create, update,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts_service
 description: "A Flutter plugin to read, create, update and delete device contacts natively on Android and iOS."
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/mustafa-707/flutter_contacts_service
 repository: https://github.com/mustafa-707/flutter_contacts_service
 issue_tracker: https://github.com/mustafa-707/flutter_contacts_service/issues


### PR DESCRIPTION
## Summary

Fixes three Android contact bugs.

Closes #6
Closes #8
Closes #9

## Fixes

- **#6 / #8 — `updateContact` failed / phone numbers not saved.** `updateContact` passed the aggregated `CONTACT_ID` to `Data`-table inserts, but Android requires the `RAW_CONTACT_ID` there. With a real device (where `CONTACT_ID != RAW_CONTACT_ID`) the whole batch failed with `raw_contact_id is required`, so **nothing** updated — including phone numbers. Now resolves the real `RAW_CONTACT_ID` first.
- **#9 — duplicate phones / emails.** A contact aggregated from multiple accounts (Google + WhatsApp + SIM …) exposes the same number in several raw contacts. `getContacts` read every `Data` row, so the same number appeared multiple times with the same label. Exact duplicates are now dropped.

## Verification

- ✅ Android APK builds; `dart analyze` clean.
- ⚠️ Contact create/update CRUD could not be exercised on a real device here — the fixes are root-cause-correct from the ContactsContract API, but a device test is recommended.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)