### PR TITLE
feat: v0.1.2 — getContacts perf, getAccounts, favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGES
 
+## 0.1.2
+
+- Performance: `getContacts` now loads contact photos in parallel and returns
+  the stored image bytes directly instead of decoding and re-encoding each one
+  — much faster on large contact lists. Resolves #3.
+- Add `FlutterContactsService.getAccounts()` — lists the device accounts that
+  own contacts (Android). Resolves #4.
+- Add favorite/starred support: the `ContactInfo.isStarred` field and
+  `FlutterContactsService.setFavorite(contact, favorite)` (Android). Resolves #11.
+- `getAccounts` returns an empty list and `setFavorite` is a no-op on iOS,
+  which has no equivalent concepts.
+
 ## 0.1.1
 
 - Fix `updateContact` failing with "raw_contact_id is required" on Android —

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = "com.example.flutter_contacts_service"
-version = "0.1.1"
+version = "0.1.2"
 
 buildscript {
     ext.kotlin_version = "2.3.21"

--- a/android/src/main/kotlin/com/example/flutter_contacts_service/FlutterContactsServicePlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_contacts_service/FlutterContactsServicePlugin.kt
@@ -8,8 +8,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
 import android.database.Cursor
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.provider.BaseColumns
 import android.provider.ContactsContract
@@ -29,7 +27,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import java.io.ByteArrayOutputStream
 import kotlinx.coroutines.*
 
 private fun Cursor.getStringOrNull(columnIndex: Int): String? {
@@ -56,6 +53,7 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                 ContactsContract.Contacts.Data.MIMETYPE,
                 ContactsContract.RawContacts.ACCOUNT_TYPE,
                 ContactsContract.RawContacts.ACCOUNT_NAME,
+                ContactsContract.Contacts.STARRED,
                 StructuredName.DISPLAY_NAME,
                 StructuredName.GIVEN_NAME,
                 StructuredName.MIDDLE_NAME,
@@ -275,9 +273,82 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                     }
                 }
             }
+            "getAccounts" -> {
+                scope.launch {
+                    try {
+                        val accounts = withContext(Dispatchers.IO) { getAccounts() }
+                        result.success(accounts)
+                    } catch (e: Exception) {
+                        result.error("ERROR", "Failed to get accounts: ${e.message}", null)
+                    }
+                }
+            }
+            "setFavorite" -> {
+                scope.launch {
+                    try {
+                        val identifier = call.argument<String>("identifier")
+                        val favorite = call.argument<Boolean>("favorite") ?: false
+                        val success =
+                            withContext(Dispatchers.IO) { setFavorite(identifier, favorite) }
+                        if (success) {
+                            result.success(null)
+                        } else {
+                            result.error("null", "Failed to update the favorite state", null)
+                        }
+                    } catch (e: Exception) {
+                        result.error("ERROR", "Failed to set favorite: ${e.message}", null)
+                    }
+                }
+            }
             else -> {
                 result.notImplemented()
             }
+        }
+    }
+
+    /** Lists the distinct accounts that own contacts on the device. */
+    private fun getAccounts(): List<Map<String, String>> {
+        val accounts = linkedSetOf<Pair<String, String>>()
+        contentResolver
+            ?.query(
+                ContactsContract.RawContacts.CONTENT_URI,
+                arrayOf(
+                    ContactsContract.RawContacts.ACCOUNT_NAME,
+                    ContactsContract.RawContacts.ACCOUNT_TYPE
+                ),
+                null,
+                null,
+                null
+            )
+            ?.use { cursor ->
+                val nameIdx = cursor.getColumnIndex(ContactsContract.RawContacts.ACCOUNT_NAME)
+                val typeIdx = cursor.getColumnIndex(ContactsContract.RawContacts.ACCOUNT_TYPE)
+                while (cursor.moveToNext()) {
+                    val name = cursor.getStringOrNull(nameIdx) ?: continue
+                    val type = cursor.getStringOrNull(typeIdx) ?: continue
+                    accounts.add(name to type)
+                }
+            }
+        return accounts.map { mapOf("name" to it.first, "type" to it.second) }
+    }
+
+    /** Stars / unstars a contact (the device "favorite" flag). */
+    private fun setFavorite(contactId: String?, favorite: Boolean): Boolean {
+        if (contactId.isNullOrEmpty()) return false
+        return try {
+            val values =
+                android.content.ContentValues().apply {
+                    put(ContactsContract.Contacts.STARRED, if (favorite) 1 else 0)
+                }
+            val uri =
+                ContentUris.withAppendedId(
+                    ContactsContract.Contacts.CONTENT_URI,
+                    contactId.toLong()
+                )
+            (contentResolver?.update(uri, values, null, null) ?: 0) > 0
+        } catch (e: Exception) {
+            Log.e("ContactsService", "Error setting favorite: ${e.message}")
+            false
         }
     }
 
@@ -308,11 +379,23 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                 }
 
             if (withThumbnails) {
-                contacts.forEach { contact ->
-                    contact.identifier?.let { id ->
-                        val avatar = loadContactPhotoHighRes(id, photoHighResolution, contentResolver)
-                        contact.avatar = avatar ?: ByteArray(0)
-                    }
+                // Load each contact's photo in parallel — sequential loading
+                // was the main cause of slow getContacts calls (issue #3).
+                coroutineScope {
+                    contacts
+                        .map { contact ->
+                            async {
+                                contact.identifier?.let { id ->
+                                    contact.avatar =
+                                        loadContactPhotoHighRes(
+                                            id,
+                                            photoHighResolution,
+                                            contentResolver
+                                        ) ?: ByteArray(0)
+                                }
+                            }
+                        }
+                        .awaitAll()
                 }
             }
 
@@ -671,6 +754,8 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                                 getStringOrNull(getColumnIndex(ContactsContract.RawContacts.ACCOUNT_TYPE))
                             androidAccountName =
                                 getStringOrNull(getColumnIndex(ContactsContract.RawContacts.ACCOUNT_NAME))
+                            isStarred =
+                                getStringOrNull(getColumnIndex(ContactsContract.Contacts.STARRED)) == "1"
                         }
 
                         when (mimeType) {
@@ -798,13 +883,10 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                 if (identifier == null || contentResolver == null) return@withContext null
 
                 val uri = ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, identifier.toLong())
-                ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, uri, highRes)?.use { stream ->
-                    val bitmap = BitmapFactory.decodeStream(stream)
-                    ByteArrayOutputStream().use { outputStream ->
-                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-                        outputStream.toByteArray()
-                    }
-                }
+                // Return the stored photo bytes directly — decoding to a Bitmap
+                // and re-encoding to PNG was slow and pointless (issue #3).
+                ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, uri, highRes)
+                    ?.use { stream -> stream.readBytes() }
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "Error loading contact photo: ${e.message}")
                 null
@@ -1155,6 +1237,7 @@ data class Contact(
     var birthday: String? = null,
     var androidAccountType: String? = null,
     var androidAccountName: String? = null,
+    var isStarred: Boolean = false,
     var emails: MutableList<Item> = mutableListOf(),
     var phones: MutableList<Item> = mutableListOf(),
     var postalAddresses: MutableList<PostalAddress> = mutableListOf(),
@@ -1177,6 +1260,7 @@ data class Contact(
             "birthday" to (birthday ?: ""),
             "androidAccountType" to (androidAccountType ?: ""),
             "androidAccountName" to (androidAccountName ?: ""),
+            "isStarred" to isStarred,
             "emails" to emails.map { it.toMap() },
             "phones" to phones.map { it.toMap() },
             "postalAddresses" to postalAddresses.map { it.toMap() }

--- a/ios/flutter_contacts_service.podspec
+++ b/ios/flutter_contacts_service.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_contacts_service'
-  s.version          = '0.1.1'
+  s.version          = '0.1.2'
   s.summary          = 'A Flutter plugin to read, create, update and delete device contacts on Android and iOS.'
   s.description      = <<-DESC
 A Flutter plugin for managing device contacts natively — read, create, update,

--- a/ios/flutter_contacts_service/Sources/flutter_contacts_service/FlutterContactsServicePlugin.swift
+++ b/ios/flutter_contacts_service/Sources/flutter_contacts_service/FlutterContactsServicePlugin.swift
@@ -127,6 +127,12 @@ public class FlutterContactsServicePlugin: NSObject, FlutterPlugin, CNContactVie
             let contact = arguments["contact"] as! [String: Any]
             let photoHighResolution = arguments["photoHighResolution"] as! Bool
             result(getAvatarForContact(contact: contact, photoHighResolution: photoHighResolution))
+        case "getAccounts":
+            // iOS has no contact-account concept exposed by CoreContacts.
+            result([])
+        case "setFavorite":
+            // The iOS Contacts framework has no favorite/starred concept — no-op.
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -96,6 +96,27 @@ class FlutterContactsService {
         },
       );
 
+  /// Lists the accounts that own contacts on the device.
+  ///
+  /// Android only — returns an empty list on iOS, which has no
+  /// contact-account concept.
+  static Future<List<ContactAccount>> getAccounts() async {
+    final List? accounts = await _channel.invokeMethod('getAccounts');
+    return accounts == null
+        ? <ContactAccount>[]
+        : accounts.map((a) => ContactAccount.fromMap(Map.from(a))).toList();
+  }
+
+  /// Marks [contact] as a favorite (starred), or removes the mark.
+  ///
+  /// Android only — a no-op on iOS, where the Contacts framework has no
+  /// favorite concept.
+  static Future<void> setFavorite(ContactInfo contact, bool favorite) =>
+      _channel.invokeMethod('setFavorite', <String, dynamic>{
+        'identifier': contact.identifier,
+        'favorite': favorite,
+      });
+
   /// Adds the [contact] to the device contact list
   static Future addContact(ContactInfo contact) => _channel.invokeMethod(
         'addContact',
@@ -237,6 +258,9 @@ class ContactInfo {
 
   String? androidAccountTypeRaw, androidAccountName;
   AndroidAccountType? androidAccountType;
+
+  /// Whether the contact is marked as a favorite (starred). Android only.
+  bool isStarred = false;
   List<ValueItem>? emails = [];
   List<ValueItem>? phones = [];
   List<PostalAddress>? postalAddresses = [];
@@ -263,6 +287,7 @@ class ContactInfo {
     androidAccountTypeRaw = m["androidAccountType"];
     androidAccountType = accountTypeFromString(androidAccountTypeRaw);
     androidAccountName = m["androidAccountName"];
+    isStarred = m["isStarred"] == true || m["isStarred"] == 1;
     emails = (m["emails"] as List?)?.map((m) => ValueItem.fromMap(m)).toList();
     phones = (m["phones"] as List?)?.map((m) => ValueItem.fromMap(m)).toList();
     postalAddresses = (m["postalAddresses"] as List?)
@@ -307,6 +332,7 @@ class ContactInfo {
       "note": contact.note,
       "androidAccountType": contact.androidAccountTypeRaw,
       "androidAccountName": contact.androidAccountName,
+      "isStarred": contact.isStarred,
       "emails": emails,
       "phones": phones,
       "postalAddresses": postalAddresses,
@@ -528,3 +554,19 @@ class ValueItem {
 }
 
 enum AndroidAccountType { facebook, google, whatsapp, other }
+
+/// An account that owns contacts on the device (Android).
+class ContactAccount {
+  final String name;
+  final String type;
+
+  const ContactAccount({required this.name, required this.type});
+
+  factory ContactAccount.fromMap(Map m) => ContactAccount(
+        name: m['name']?.toString() ?? '',
+        type: m['type']?.toString() ?? '',
+      );
+
+  @override
+  String toString() => 'ContactAccount(name: $name, type: $type)';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts_service
 description: "A Flutter plugin to read, create, update and delete device contacts natively on Android and iOS."
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/mustafa-707/flutter_contacts_service
 repository: https://github.com/mustafa-707/flutter_contacts_service
 issue_tracker: https://github.com/mustafa-707/flutter_contacts_service/issues


### PR DESCRIPTION
## Summary

Addresses three of the remaining open issues.

Closes #3
Closes #4
Closes #11

## Changes

- **#3 — `getContacts` slow.** Photos were loaded **sequentially**, and each was decoded to a `Bitmap` then re-encoded to PNG. Now photos load **in parallel** and the stored image bytes are returned directly (no decode/re-encode). Big speedup on large contact lists.
- **#4 — accounts.** New `FlutterContactsService.getAccounts()` lists the device accounts that own contacts (`name` + `type`), read from the contacts provider — Android.
- **#11 — favorites.** New `ContactInfo.isStarred` field and `FlutterContactsService.setFavorite(contact, favorite)` — reads/sets the device "starred" flag on Android.
- iOS: `getAccounts()` returns an empty list and `setFavorite()` is a no-op — iOS has no equivalent concepts.

## Verification

- ✅ Android APK + iOS build; `dart analyze` clean; `dart format` clean.
- ⚠️ Contact-provider behavior (favorites write, account listing) could not be device-tested here — implementations are API-correct; a real-device check is recommended.

> Not addressed: **#5 (VCard)** — a large feature (Android has no public vCard API; needs a hand-rolled serializer/parser), best done as its own focused effort. **#10** — no code-level bug found; awaiting reporter details.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)