### PR TITLE
feat: v0.2.0 — vCard import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGES
 
+## 0.2.0
+
+- Add **vCard 3.0 support** — `FlutterContactsService.exportVCard(contacts)`
+  serializes contacts to a vCard document, and `importVCard(vCard)` parses one
+  back into `ContactInfo` objects. iOS uses `CNContactVCardSerialization`;
+  Android uses a built-in serializer/parser (name, organization, phones,
+  emails, postal addresses, note, birthday). Resolves #5.
+
 ## 0.1.2
 
 - Performance: `getContacts` now loads contact photos in parallel and returns

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = "com.example.flutter_contacts_service"
-version = "0.1.2"
+version = "0.2.0"
 
 buildscript {
     ext.kotlin_version = "2.3.21"

--- a/android/src/main/kotlin/com/example/flutter_contacts_service/FlutterContactsServicePlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_contacts_service/FlutterContactsServicePlugin.kt
@@ -273,6 +273,29 @@ class FlutterContactsServicePlugin : MethodCallHandler, FlutterPlugin, ActivityA
                     }
                 }
             }
+            "exportVCard" -> {
+                scope.launch {
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        val list = (call.arguments as? List<Map<String, Any?>>) ?: emptyList()
+                        val vcard = withContext(Dispatchers.Default) { VCard.serialize(list) }
+                        result.success(vcard)
+                    } catch (e: Exception) {
+                        result.error("ERROR", "Failed to export vCard: ${e.message}", null)
+                    }
+                }
+            }
+            "importVCard" -> {
+                scope.launch {
+                    try {
+                        val text = call.arguments as? String ?: ""
+                        val contacts = withContext(Dispatchers.Default) { VCard.parse(text) }
+                        result.success(contacts)
+                    } catch (e: Exception) {
+                        result.error("ERROR", "Failed to import vCard: ${e.message}", null)
+                    }
+                }
+            }
             "getAccounts" -> {
                 scope.launch {
                     try {

--- a/android/src/main/kotlin/com/example/flutter_contacts_service/VCard.kt
+++ b/android/src/main/kotlin/com/example/flutter_contacts_service/VCard.kt
@@ -1,0 +1,217 @@
+package com.example.flutter_contacts_service
+
+/**
+ * Minimal vCard 3.0 serializer / parser for `Contact`-shaped maps.
+ *
+ * Android has no public vCard API, so this is a self-contained implementation
+ * covering the fields this plugin exposes: name, organization, phones, emails,
+ * postal addresses, note and birthday.
+ */
+internal object VCard {
+
+    /** Serializes contact maps into a single vCard 3.0 document. */
+    fun serialize(contacts: List<Map<String, Any?>>): String =
+        contacts.joinToString("\r\n") { serializeOne(it) }
+
+    private fun serializeOne(c: Map<String, Any?>): String {
+        val sb = StringBuilder()
+        sb.append("BEGIN:VCARD\r\n")
+        sb.append("VERSION:3.0\r\n")
+
+        val given = str(c["givenName"])
+        val middle = str(c["middleName"])
+        val family = str(c["familyName"])
+        val prefix = str(c["prefix"])
+        val suffix = str(c["suffix"])
+        sb.append("N:${esc(family)};${esc(given)};${esc(middle)};${esc(prefix)};${esc(suffix)}\r\n")
+
+        val fn =
+            str(c["displayName"]).ifBlank {
+                listOf(prefix, given, middle, family, suffix)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" ")
+            }
+        if (fn.isNotBlank()) sb.append("FN:${esc(fn)}\r\n")
+
+        str(c["company"]).takeIf { it.isNotBlank() }?.let { sb.append("ORG:${esc(it)}\r\n") }
+        str(c["jobTitle"]).takeIf { it.isNotBlank() }?.let { sb.append("TITLE:${esc(it)}\r\n") }
+
+        (c["phones"] as? List<*>)?.forEach { p ->
+            val m = p as? Map<*, *> ?: return@forEach
+            val value = str(m["value"])
+            if (value.isNotBlank()) {
+                val label = str(m["label"]).ifBlank { "voice" }
+                sb.append("TEL;TYPE=${esc(label)}:${esc(value)}\r\n")
+            }
+        }
+        (c["emails"] as? List<*>)?.forEach { e ->
+            val m = e as? Map<*, *> ?: return@forEach
+            val value = str(m["value"])
+            if (value.isNotBlank()) {
+                val label = str(m["label"]).ifBlank { "internet" }
+                sb.append("EMAIL;TYPE=${esc(label)}:${esc(value)}\r\n")
+            }
+        }
+        (c["postalAddresses"] as? List<*>)?.forEach { a ->
+            val m = a as? Map<*, *> ?: return@forEach
+            val label = str(m["label"]).ifBlank { "home" }
+            // ADR structure: po-box;extended;street;city;region;postcode;country
+            sb.append(
+                "ADR;TYPE=${esc(label)}:;;${esc(str(m["street"]))};${esc(str(m["city"]))};" +
+                    "${esc(str(m["region"]))};${esc(str(m["postcode"]))};${esc(str(m["country"]))}\r\n"
+            )
+        }
+
+        str(c["note"]).takeIf { it.isNotBlank() }?.let { sb.append("NOTE:${esc(it)}\r\n") }
+        str(c["birthday"]).takeIf { it.isNotBlank() }?.let { sb.append("BDAY:${esc(it)}\r\n") }
+
+        sb.append("END:VCARD")
+        return sb.toString()
+    }
+
+    /** Parses a vCard document into contact maps (one per `VCARD` block). */
+    fun parse(text: String): List<Map<String, Any?>> {
+        val cards = mutableListOf<Map<String, Any?>>()
+        var current: MutableMap<String, Any?>? = null
+        var phones = mutableListOf<Map<String, String>>()
+        var emails = mutableListOf<Map<String, String>>()
+        var addresses = mutableListOf<Map<String, String>>()
+
+        for (line in unfold(text)) {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) continue
+            when {
+                trimmed.equals("BEGIN:VCARD", ignoreCase = true) -> {
+                    current = mutableMapOf()
+                    phones = mutableListOf()
+                    emails = mutableListOf()
+                    addresses = mutableListOf()
+                }
+                trimmed.equals("END:VCARD", ignoreCase = true) -> {
+                    current?.let {
+                        it["phones"] = phones
+                        it["emails"] = emails
+                        it["postalAddresses"] = addresses
+                        cards.add(it)
+                    }
+                    current = null
+                }
+                current != null -> parseLine(trimmed, current, phones, emails, addresses)
+            }
+        }
+        return cards
+    }
+
+    private fun parseLine(
+        line: String,
+        c: MutableMap<String, Any?>,
+        phones: MutableList<Map<String, String>>,
+        emails: MutableList<Map<String, String>>,
+        addresses: MutableList<Map<String, String>>
+    ) {
+        val colon = line.indexOf(':')
+        if (colon < 0) return
+        val header = line.substring(0, colon).split(';')
+        val value = line.substring(colon + 1)
+        val name = header[0].substringBefore('.').uppercase() // drop optional group prefix
+        val type =
+            header.drop(1)
+                .firstOrNull { it.uppercase().startsWith("TYPE=") }
+                ?.substringAfter('=')
+                ?.lowercase()
+                .orEmpty()
+
+        when (name) {
+            "N" -> {
+                val f = splitValue(value)
+                c["familyName"] = f.getOrElse(0) { "" }
+                c["givenName"] = f.getOrElse(1) { "" }
+                c["middleName"] = f.getOrElse(2) { "" }
+                c["prefix"] = f.getOrElse(3) { "" }
+                c["suffix"] = f.getOrElse(4) { "" }
+            }
+            "FN" -> c["displayName"] = unesc(value)
+            "ORG" -> c["company"] = splitValue(value).firstOrNull().orEmpty()
+            "TITLE" -> c["jobTitle"] = unesc(value)
+            "NOTE" -> c["note"] = unesc(value)
+            "BDAY" -> c["birthday"] = unesc(value)
+            "TEL" ->
+                phones.add(mapOf("label" to type.ifBlank { "voice" }, "value" to unesc(value)))
+            "EMAIL" ->
+                emails.add(mapOf("label" to type.ifBlank { "internet" }, "value" to unesc(value)))
+            "ADR" -> {
+                val f = splitValue(value)
+                addresses.add(
+                    mapOf(
+                        "label" to type.ifBlank { "home" },
+                        "street" to f.getOrElse(2) { "" },
+                        "city" to f.getOrElse(3) { "" },
+                        "region" to f.getOrElse(4) { "" },
+                        "postcode" to f.getOrElse(5) { "" },
+                        "country" to f.getOrElse(6) { "" }
+                    )
+                )
+            }
+        }
+    }
+
+    /** Joins folded continuation lines (RFC 2425 line folding). */
+    private fun unfold(text: String): List<String> {
+        val out = mutableListOf<String>()
+        for (line in text.split("\r\n", "\n")) {
+            if ((line.startsWith(" ") || line.startsWith("\t")) && out.isNotEmpty()) {
+                out[out.size - 1] = out[out.size - 1] + line.substring(1)
+            } else {
+                out.add(line)
+            }
+        }
+        return out
+    }
+
+    private fun esc(s: String): String =
+        s.replace("\\", "\\\\").replace("\n", "\\n").replace(",", "\\,").replace(";", "\\;")
+
+    private fun unesc(s: String): String {
+        val sb = StringBuilder()
+        var i = 0
+        while (i < s.length) {
+            val ch = s[i]
+            if (ch == '\\' && i + 1 < s.length) {
+                when (s[i + 1]) {
+                    'n', 'N' -> sb.append('\n')
+                    else -> sb.append(s[i + 1])
+                }
+                i += 2
+            } else {
+                sb.append(ch)
+                i++
+            }
+        }
+        return sb.toString()
+    }
+
+    /** Splits a structured value on unescaped `;`, then unescapes each field. */
+    private fun splitValue(s: String): List<String> {
+        val parts = mutableListOf<String>()
+        val sb = StringBuilder()
+        var i = 0
+        while (i < s.length) {
+            val ch = s[i]
+            if (ch == '\\' && i + 1 < s.length) {
+                sb.append(ch).append(s[i + 1])
+                i += 2
+            } else if (ch == ';') {
+                parts.add(unesc(sb.toString()))
+                sb.setLength(0)
+                i++
+            } else {
+                sb.append(ch)
+                i++
+            }
+        }
+        parts.add(unesc(sb.toString()))
+        return parts
+    }
+
+    private fun str(v: Any?): String = v?.toString() ?: ""
+}

--- a/ios/flutter_contacts_service.podspec
+++ b/ios/flutter_contacts_service.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_contacts_service'
-  s.version          = '0.1.2'
+  s.version          = '0.2.0'
   s.summary          = 'A Flutter plugin to read, create, update and delete device contacts on Android and iOS.'
   s.description      = <<-DESC
 A Flutter plugin for managing device contacts natively — read, create, update,

--- a/ios/flutter_contacts_service/Sources/flutter_contacts_service/FlutterContactsServicePlugin.swift
+++ b/ios/flutter_contacts_service/Sources/flutter_contacts_service/FlutterContactsServicePlugin.swift
@@ -127,6 +127,30 @@ public class FlutterContactsServicePlugin: NSObject, FlutterPlugin, CNContactVie
             let contact = arguments["contact"] as! [String: Any]
             let photoHighResolution = arguments["photoHighResolution"] as! Bool
             result(getAvatarForContact(contact: contact, photoHighResolution: photoHighResolution))
+        case "exportVCard":
+            let contactsArray = call.arguments as? [[String: Any]] ?? []
+            let cnContacts = contactsArray.map { dictionaryToContact(dictionary: $0) as CNContact }
+            do {
+                let data = try CNContactVCardSerialization.data(with: cnContacts)
+                result(String(data: data, encoding: .utf8) ?? "")
+            } catch {
+                result(
+                    FlutterError(
+                        code: "VCARD_ERROR", message: error.localizedDescription, details: nil))
+            }
+        case "importVCard":
+            let text = call.arguments as? String ?? ""
+            do {
+                let cnContacts = try CNContactVCardSerialization.contacts(with: Data(text.utf8))
+                result(
+                    cnContacts.map {
+                        contactToDictionary(contact: $0, localizedLabels: localizedLabels)
+                    })
+            } catch {
+                result(
+                    FlutterError(
+                        code: "VCARD_ERROR", message: error.localizedDescription, details: nil))
+            }
         case "getAccounts":
             // iOS has no contact-account concept exposed by CoreContacts.
             result([])
@@ -589,7 +613,11 @@ public class FlutterContactsServicePlugin: NSObject, FlutterPlugin, CNContactVie
         result["givenName"] = contact.givenName
         result["familyName"] = contact.familyName
         result["middleName"] = contact.middleName
-        result["note"] = contact.note
+        // `note` is entitlement-gated and may not be fetched (e.g. for
+        // vCard-parsed contacts) — accessing it then would throw.
+        if contact.isKeyAvailable(CNContactNoteKey) {
+            result["note"] = contact.note
+        }
         result["prefix"] = contact.namePrefix
         result["suffix"] = contact.nameSuffix
         result["company"] = contact.organizationName

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -117,6 +117,24 @@ class FlutterContactsService {
         'favorite': favorite,
       });
 
+  /// Serializes [contacts] into a vCard 3.0 document.
+  static Future<String> exportVCard(List<ContactInfo> contacts) async {
+    final result = await _channel.invokeMethod<String>(
+      'exportVCard',
+      contacts.map((c) => ContactInfo._toMap(c)).toList(),
+    );
+    return result ?? '';
+  }
+
+  /// Parses a vCard document into [ContactInfo] objects.
+  ///
+  /// The returned contacts are not written to the device — pass them to
+  /// [addContact] if you want to persist them.
+  static Future<List<ContactInfo>> importVCard(String vCard) async {
+    final List result = await _channel.invokeMethod('importVCard', vCard) ?? [];
+    return result.map((m) => ContactInfo.fromMap(m)).toList();
+  }
+
   /// Adds the [contact] to the device contact list
   static Future addContact(ContactInfo contact) => _channel.invokeMethod(
         'addContact',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_contacts_service
 description: "A Flutter plugin to read, create, update and delete device contacts natively on Android and iOS."
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/mustafa-707/flutter_contacts_service
 repository: https://github.com/mustafa-707/flutter_contacts_service
 issue_tracker: https://github.com/mustafa-707/flutter_contacts_service/issues


### PR DESCRIPTION
## Summary

Adds vCard 3.0 import / export.

Closes #5

## API

- `FlutterContactsService.exportVCard(List<ContactInfo>)` → `String` — serializes contacts to a vCard 3.0 document.
- `FlutterContactsService.importVCard(String)` → `List<ContactInfo>` — parses a vCard document back into contacts (not written to the device — pass to `addContact` to persist).

## Implementation

- **iOS** — `CNContactVCardSerialization` (the system API). `note` access in the contact mapper is now guarded with `isKeyAvailable`, since vCard-parsed contacts don't carry that key.
- **Android** — Android has no public vCard API, so this ships a self-contained `VCard` serializer/parser (`VCard.kt`) for vCard 3.0: name, organization, phones, emails, postal addresses, note, birthday — with proper escaping and RFC 2425 line-unfolding.

## Verification

- ✅ Android APK + iOS build; `dart analyze` clean; `dart format` clean.
- ⚠️ vCard round-tripping was not exercised against real contact data here — the implementation follows the vCard 3.0 spec and `CNContactVCardSerialization`, but a real-data test is recommended.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)